### PR TITLE
add GA tracking number

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,9 @@ theme: minima
 plugins:
   - jekyll-feed
 
+# Google Analytics
+google_analytics: UA-150353153-2
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
This should add the tracking number in the [default include](https://github.com/jekyll/minima/blob/master/_includes/google-analytics.html#L8).